### PR TITLE
Update `src/` to reflect current dev head 

### DIFF
--- a/src/contracts/FraxlendPair.sol
+++ b/src/contracts/FraxlendPair.sol
@@ -522,6 +522,7 @@ contract FraxlendPair is IERC20Metadata, FraxlendPairCore {
         if (!isLiquidateAccessControlRevoked) _pauseLiquidate(false);
         if (!isInterestAccessControlRevoked) {
             _addInterest();
+            currentRateInfo.lastTimestamp = uint64(block.timestamp);
             _pauseInterest(false);
         }
     }
@@ -635,6 +636,7 @@ contract FraxlendPair is IERC20Metadata, FraxlendPairCore {
         if (isInterestAccessControlRevoked) revert AccessControlRevoked();
         // Resets the lastTimestamp which has the effect of no interest accruing over the pause period
         _addInterest();
+        if (_isPaused == false) currentRateInfo.lastTimestamp = uint64(block.timestamp);
         _pauseInterest(_isPaused);
     }
 

--- a/src/contracts/FraxlendPairCore.sol
+++ b/src/contracts/FraxlendPairCore.sol
@@ -1130,6 +1130,9 @@ abstract contract FraxlendPairCore is FraxlendPairAccessControl, FraxlendPairCon
         {
             (bool _isBorrowAllowed, , ) = _updateExchangeRate();
             if (!_isBorrowAllowed) revert ExceedsMaxOracleDeviation();
+
+            // Check if borrow will violate the borrow limit and revert if necessary
+            if (borrowLimit < totalBorrow.amount + _borrowAmount) revert ExceedsBorrowLimit();
         }
 
         IERC20 _assetContract = assetContract;

--- a/src/contracts/interfaces/IConvexStakingWrapperFraxlend.sol
+++ b/src/contracts/interfaces/IConvexStakingWrapperFraxlend.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.19;
+
+// NOTE: This is a generated file. Do not edit directly.
+
+interface IConvexStakingWrapperFraxlend {
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Deposited(address indexed _user, address indexed _account, uint256 _amount, bool _wrapped);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Withdrawn(address indexed _user, uint256 _amount, bool _unwrapped);
+
+    struct EarnedData {
+        address token;
+        uint256 amount;
+    }
+
+    function addRewards() external;
+
+    function addTokenReward(address _token) external;
+
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    function balanceOf(address account) external view returns (uint256);
+
+    function collateralVault() external view returns (address);
+
+    function convexBooster() external view returns (address);
+
+    function convexPool() external view returns (address);
+
+    function convexPoolId() external view returns (uint256);
+
+    function convexToken() external view returns (address);
+
+    function crv() external view returns (address);
+
+    function curveToken() external view returns (address);
+
+    function cvx() external view returns (address);
+
+    function decimals() external view returns (uint8);
+
+    function decreaseAllowance(address spender, uint256 subtractedValue) external returns (bool);
+
+    function deposit(uint256 _amount, address _to) external;
+
+    function earned(address _account) external returns (IConvexStakingWrapperFraxlend.EarnedData[] memory claimable);
+
+    function earnedView(
+        address _account
+    ) external view returns (IConvexStakingWrapperFraxlend.EarnedData[] memory claimable);
+
+    function getReward(address _account, address _forwardTo) external;
+
+    function getReward(address _account) external;
+
+    function increaseAllowance(address spender, uint256 addedValue) external returns (bool);
+
+    function initialize(uint256 _poolId) external;
+
+    function isInit() external view returns (bool);
+
+    function isShutdown() external view returns (bool);
+
+    function name() external view returns (string memory);
+
+    function owner() external view returns (address);
+
+    function registeredRewards(address) external view returns (uint256);
+
+    function renounceOwnership() external;
+
+    function rewardHook() external view returns (address);
+
+    function rewardLength() external view returns (uint256);
+
+    function rewards(
+        uint256
+    )
+        external
+        view
+        returns (address reward_token, address reward_pool, uint128 reward_integral, uint128 reward_remaining);
+
+    function setApprovals() external;
+
+    function setHook(address _hook) external;
+
+    function setVault(address _vault) external;
+
+    function shutdown() external;
+
+    function stake(uint256 _amount, address _to) external;
+
+    function symbol() external view returns (string memory);
+
+    function totalBalanceOf(address _account) external view returns (uint256);
+
+    function totalSupply() external view returns (uint256);
+
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    function transferOwnership(address newOwner) external;
+
+    function user_checkpoint(address _account) external returns (bool);
+
+    function withdraw(uint256 _amount) external;
+
+    function withdrawAndUnwrap(uint256 _amount) external;
+}

--- a/src/contracts/interfaces/IDualOracle.sol
+++ b/src/contracts/interfaces/IDualOracle.sol
@@ -33,4 +33,6 @@ interface IDualOracle is IERC165 {
     function QUOTE_TOKEN_1() external view returns (address);
 
     function QUOTE_TOKEN_1_DECIMALS() external view returns (uint256);
+
+    function CHAINLINK_FEED_ADDRESS() external view returns (address);
 }

--- a/src/contracts/interfaces/IERC4626.sol
+++ b/src/contracts/interfaces/IERC4626.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: ISC
+pragma solidity >=0.8.19;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+interface IERC4626 is IERC20, IERC20Metadata {
+    event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
+    event Withdraw(
+        address indexed caller,
+        address indexed receiver,
+        address indexed owner,
+        uint256 assets,
+        uint256 shares
+    );
+
+    function asset() external view returns (address);
+
+    function convertToAssets(uint256 shares) external view returns (uint256);
+
+    function convertToShares(uint256 assets) external view returns (uint256);
+
+    function maxDeposit(address) external view returns (uint256);
+
+    function maxMint(address) external view returns (uint256);
+
+    function maxRedeem(address owner) external view returns (uint256);
+
+    function maxWithdraw(address owner) external view returns (uint256);
+
+    function previewDeposit(uint256 assets) external view returns (uint256);
+
+    function previewMint(uint256 shares) external view returns (uint256);
+
+    function previewRedeem(uint256 shares) external view returns (uint256);
+
+    function previewWithdraw(uint256 assets) external view returns (uint256);
+
+    function totalAssets() external view returns (uint256);
+
+    function mint(uint256 shares, address receiver) external returns (uint256 assets);
+
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+
+    function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
+
+    function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
+}

--- a/src/contracts/interfaces/IFPIControllerPool.sol
+++ b/src/contracts/interfaces/IFPIControllerPool.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: ISC
+pragma solidity >=0.8.19;
+
+// NOTE: This file generated from FPIController contract at https://etherscan.io/address/0x2397321b301B80A1C0911d6f9ED4b6033d43cF51#code
+
+interface IFPIControllerPool {
+    function FEE_PRECISION() external view returns (uint256);
+
+    function FPI_TKN() external view returns (address);
+
+    function FRAX() external view returns (address);
+
+    function PEG_BAND_PRECISION() external view returns (uint256);
+
+    function PRICE_PRECISION() external view returns (uint256);
+
+    function TWAMM() external view returns (address);
+
+    function acceptOwnership() external;
+
+    function addAMO(address amo_address) external;
+
+    function amos(address) external view returns (bool);
+
+    function amos_array(uint256) external view returns (address);
+
+    function burnFPI(bool burn_all, uint256 fpi_amount) external;
+
+    function calcMintFPI(uint256 frax_in, uint256 min_fpi_out) external view returns (uint256 fpi_out);
+
+    function calcRedeemFPI(uint256 fpi_in, uint256 min_frax_out) external view returns (uint256 frax_out);
+
+    function cancelCurrTWAMMOrder(uint256 order_id_override) external;
+
+    function chainlink_fpi_usd_decimals() external view returns (uint256);
+
+    function chainlink_frax_usd_decimals() external view returns (uint256);
+
+    function collectCurrTWAMMProceeds(uint256 order_id_override) external;
+
+    function cpiTracker() external view returns (address);
+
+    function dollarBalances() external view returns (uint256 frax_val_e18, uint256 collat_val_e18);
+
+    function fpi_mint_cap() external view returns (uint256);
+
+    function frax_borrow_cap() external view returns (int256);
+
+    function frax_borrowed_balances(address) external view returns (int256);
+
+    function frax_borrowed_sum() external view returns (int256);
+
+    function frax_is_token0() external view returns (bool);
+
+    function getFPIPriceE18() external view returns (uint256);
+
+    function getFRAXPriceE18() external view returns (uint256);
+
+    function getReservesAndFPISpot() external returns (uint256 reserveFRAX, uint256 reserveFPI, uint256 fpi_price);
+
+    function giveFRAXToAMO(address destination_amo, uint256 frax_amount) external;
+
+    function last_order_id_twamm() external view returns (uint256);
+
+    function max_swap_fpi_amt_in() external view returns (uint256);
+
+    function max_swap_frax_amt_in() external view returns (uint256);
+
+    function mintFPI(uint256 frax_in, uint256 min_fpi_out) external returns (uint256 fpi_out);
+
+    function mint_fee() external view returns (uint256 fee);
+
+    function mint_fee_manual() external view returns (uint256);
+
+    function mint_fee_multiplier() external view returns (uint256);
+
+    function mints_paused() external view returns (bool);
+
+    function nominateNewOwner(address _owner) external;
+
+    function nominatedOwner() external view returns (address);
+
+    function num_twamm_intervals() external view returns (uint256);
+
+    function owner() external view returns (address);
+
+    function pegStatusMntRdm() external view returns (uint256 cpi_peg_price, uint256 diff_frac_abs, bool within_range);
+
+    function peg_band_mint_redeem() external view returns (uint256);
+
+    function peg_band_twamm() external view returns (uint256);
+
+    function pending_twamm_order() external view returns (bool);
+
+    function priceFeedFPIUSD() external view returns (address);
+
+    function priceFeedFRAXUSD() external view returns (address);
+
+    function price_info()
+        external
+        view
+        returns (int256 collat_imbalance, uint256 cpi_peg_price, uint256 fpi_price, uint256 price_diff_frac_abs);
+
+    function receiveFRAXFromAMO(uint256 frax_amount) external;
+
+    function recoverERC20(address tokenAddress, uint256 tokenAmount) external;
+
+    function redeemFPI(uint256 fpi_in, uint256 min_frax_out) external returns (uint256 frax_out);
+
+    function redeem_fee() external view returns (uint256 fee);
+
+    function redeem_fee_manual() external view returns (uint256);
+
+    function redeem_fee_multiplier() external view returns (uint256);
+
+    function redeems_paused() external view returns (bool);
+
+    function removeAMO(address amo_address) external;
+
+    function setFraxBorrowCap(int256 _frax_borrow_cap) external;
+
+    function setMintCap(uint256 _fpi_mint_cap) external;
+
+    function setMintRedeemFees(
+        bool _use_manual_mint_fee,
+        uint256 _mint_fee_manual,
+        uint256 _mint_fee_multiplier,
+        bool _use_manual_redeem_fee,
+        uint256 _redeem_fee_manual,
+        uint256 _redeem_fee_multiplier
+    ) external;
+
+    function setOracles(address _frax_oracle, address _fpi_oracle, address _cpi_oracle) external;
+
+    function setPegBands(uint256 _peg_band_mint_redeem, uint256 _peg_band_twamm) external;
+
+    function setTWAMMAndSwapPeriod(address _twamm_addr, uint256 _swap_period) external;
+
+    function setTWAMMMaxSwapIn(uint256 _max_swap_frax_amt_in, uint256 _max_swap_fpi_amt_in) external;
+
+    function setTimelock(address _new_timelock_address) external;
+
+    function swap_period() external view returns (uint256);
+
+    function timelock_address() external view returns (address);
+
+    function toggleMints() external;
+
+    function toggleRedeems() external;
+
+    function twammManual(
+        uint256 frax_sell_amt,
+        uint256 fpi_sell_amt,
+        uint256 override_intervals
+    ) external returns (uint256 frax_to_use, uint256 fpi_to_use);
+
+    function use_manual_mint_fee() external view returns (bool);
+
+    function use_manual_redeem_fee() external view returns (bool);
+}

--- a/src/contracts/interfaces/IFrxEthStableSwap.sol
+++ b/src/contracts/interfaces/IFrxEthStableSwap.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19;
+
+// NOTE: This file generated from ABI of the frxEth/Eth curve pool found at https://etherscan.io/address/0xa1f8a6807c402e4a15ef4eba36528a3fed24e577#code
+
+interface IFrxEthStableSwap {
+    event AddLiquidity(
+        address indexed provider,
+        uint256[2] token_amounts,
+        uint256[2] fees,
+        uint256 invariant,
+        uint256 token_supply
+    );
+    event CommitNewAdmin(uint256 indexed deadline, address indexed admin);
+    event CommitNewFee(uint256 indexed deadline, uint256 fee, uint256 admin_fee);
+    event NewAdmin(address indexed admin);
+    event NewFee(uint256 fee, uint256 admin_fee);
+    event RampA(uint256 old_A, uint256 new_A, uint256 initial_time, uint256 future_time);
+    event RemoveLiquidity(address indexed provider, uint256[2] token_amounts, uint256[2] fees, uint256 token_supply);
+    event RemoveLiquidityImbalance(
+        address indexed provider,
+        uint256[2] token_amounts,
+        uint256[2] fees,
+        uint256 invariant,
+        uint256 token_supply
+    );
+    event RemoveLiquidityOne(address indexed provider, uint256 token_amount, uint256 coin_amount, uint256 token_supply);
+    event StopRampA(uint256 A, uint256 t);
+    event TokenExchange(
+        address indexed buyer,
+        int128 sold_id,
+        uint256 tokens_sold,
+        int128 bought_id,
+        uint256 tokens_bought
+    );
+
+    function A() external view returns (uint256);
+
+    function A_precise() external view returns (uint256);
+
+    function add_liquidity(uint256[2] memory _amounts, uint256 _min_mint_amount) external payable returns (uint256);
+
+    function admin_actions_deadline() external view returns (uint256);
+
+    function admin_balances(uint256 i) external view returns (uint256);
+
+    function admin_fee() external view returns (uint256);
+
+    function apply_new_fee() external;
+
+    function apply_transfer_ownership() external;
+
+    function balances(uint256 arg0) external view returns (uint256);
+
+    function calc_token_amount(uint256[2] memory _amounts, bool _is_deposit) external view returns (uint256);
+
+    function calc_withdraw_one_coin(uint256 _token_amount, int128 i) external view returns (uint256);
+
+    function coins(uint256 arg0) external view returns (address);
+
+    function commit_new_fee(uint256 _new_fee, uint256 _new_admin_fee) external;
+
+    function commit_transfer_ownership(address _owner) external;
+
+    function donate_admin_fees() external;
+
+    function exchange(int128 i, int128 j, uint256 _dx, uint256 _min_dy) external payable returns (uint256);
+
+    function fee() external view returns (uint256);
+
+    function future_A() external view returns (uint256);
+
+    function future_A_time() external view returns (uint256);
+
+    function future_admin_fee() external view returns (uint256);
+
+    function future_fee() external view returns (uint256);
+
+    function future_owner() external view returns (address);
+
+    function get_dy(int128 i, int128 j, uint256 _dx) external view returns (uint256);
+
+    function get_p() external view returns (uint256);
+
+    function get_virtual_price() external view returns (uint256);
+
+    function initial_A() external view returns (uint256);
+
+    function initial_A_time() external view returns (uint256);
+
+    function kill_me() external;
+
+    function lp_token() external view returns (address);
+
+    function ma_exp_time() external view returns (uint256);
+
+    function ma_last_time() external view returns (uint256);
+
+    function owner() external view returns (address);
+
+    function price_oracle() external view returns (uint256);
+
+    function ramp_A(uint256 _future_A, uint256 _future_time) external;
+
+    function remove_liquidity(uint256 _amount, uint256[2] memory _min_amounts) external returns (uint256[2] memory);
+
+    function remove_liquidity_imbalance(
+        uint256[2] memory _amounts,
+        uint256 _max_burn_amount
+    ) external returns (uint256);
+
+    function remove_liquidity_one_coin(uint256 _token_amount, int128 i, uint256 _min_amount) external returns (uint256);
+
+    function revert_new_parameters() external;
+
+    function revert_transfer_ownership() external;
+
+    function set_ma_exp_time(uint256 _ma_exp_time) external;
+
+    function stop_ramp_A() external;
+
+    function transfer_ownership_deadline() external view returns (uint256);
+
+    function unkill_me() external;
+
+    function withdraw_admin_fees() external;
+}

--- a/src/contracts/interfaces/IGOhm.sol
+++ b/src/contracts/interfaces/IGOhm.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19;
+
+// NOTE: This file generated from gOHm contract at https://etherscan.io/address/0x0ab87046fBb341D058F17CBC4c1133F25a20a52f#code
+
+interface IGOhm {
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    function approved() external view returns (address);
+
+    function balanceFrom(uint256 _amount) external view returns (uint256);
+
+    function balanceOf(address account) external view returns (uint256);
+
+    function balanceTo(uint256 _amount) external view returns (uint256);
+
+    function burn(address _from, uint256 _amount) external;
+
+    function checkpoints(address, uint256) external view returns (uint256 fromBlock, uint256 votes);
+
+    function decimals() external view returns (uint8);
+
+    function decreaseAllowance(address spender, uint256 subtractedValue) external returns (bool);
+
+    function delegate(address delegatee) external;
+
+    function delegates(address) external view returns (address);
+
+    function getCurrentVotes(address account) external view returns (uint256);
+
+    function getPriorVotes(address account, uint256 blockNumber) external view returns (uint256);
+
+    function increaseAllowance(address spender, uint256 addedValue) external returns (bool);
+
+    function index() external view returns (uint256);
+
+    function migrate(address _staking, address _sOHM) external;
+
+    function migrated() external view returns (bool);
+
+    function mint(address _to, uint256 _amount) external;
+
+    function name() external view returns (string memory);
+
+    function numCheckpoints(address) external view returns (uint256);
+
+    function sOHM() external view returns (address);
+
+    function symbol() external view returns (string memory);
+
+    function totalSupply() external view returns (uint256);
+
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+}

--- a/src/contracts/interfaces/ISfrxEth.sol
+++ b/src/contracts/interfaces/ISfrxEth.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19;
+
+// NOTE: This file generated from sfrxEth contract at https://etherscan.io/address/0xac3e018457b222d93114458476f3e3416abbe38f#code
+interface ISfrxEth {
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+    function allowance(address, address) external view returns (uint256);
+
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    function asset() external view returns (address);
+
+    function balanceOf(address) external view returns (uint256);
+
+    function convertToAssets(uint256 shares) external view returns (uint256);
+
+    function convertToShares(uint256 assets) external view returns (uint256);
+
+    function decimals() external view returns (uint8);
+
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+
+    function depositWithSignature(
+        uint256 assets,
+        address receiver,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 shares);
+
+    function lastRewardAmount() external view returns (uint192);
+
+    function lastSync() external view returns (uint32);
+
+    function maxDeposit(address) external view returns (uint256);
+
+    function maxMint(address) external view returns (uint256);
+
+    function maxRedeem(address owner) external view returns (uint256);
+
+    function maxWithdraw(address owner) external view returns (uint256);
+
+    function mint(uint256 shares, address receiver) external returns (uint256 assets);
+
+    function name() external view returns (string memory);
+
+    function nonces(address) external view returns (uint256);
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function previewDeposit(uint256 assets) external view returns (uint256);
+
+    function previewMint(uint256 shares) external view returns (uint256);
+
+    function previewRedeem(uint256 shares) external view returns (uint256);
+
+    function previewWithdraw(uint256 assets) external view returns (uint256);
+
+    function pricePerShare() external view returns (uint256);
+
+    function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
+
+    function rewardsCycleEnd() external view returns (uint32);
+
+    function rewardsCycleLength() external view returns (uint32);
+
+    function symbol() external view returns (string memory);
+
+    function syncRewards() external;
+
+    function totalAssets() external view returns (uint256);
+
+    function totalSupply() external view returns (uint256);
+
+    function transfer(address to, uint256 amount) external returns (bool);
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+
+    function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
+}

--- a/src/contracts/interfaces/IStableSwap.sol
+++ b/src/contracts/interfaces/IStableSwap.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19;
+
+// NOTE: This file generated from ABI of the FraxBP pool found at https://etherscan.io/address/0xDcEF968d416a41Cdac0ED8702fAC8128A64241A2#code
+
+interface IStableSwap {
+    function A() external view returns (uint256);
+
+    function A_precise() external view returns (uint256);
+
+    function get_virtual_price() external view returns (uint256);
+
+    function calc_token_amount(uint256[2] memory _amounts, bool _is_deposit) external view returns (uint256);
+
+    function add_liquidity(uint256[2] memory _amounts, uint256 _min_mint_amount) external returns (uint256);
+
+    function get_dy(int128 i, int128 j, uint256 _dx) external view returns (uint256);
+
+    function exchange(int128 i, int128 j, uint256 _dx, uint256 _min_dy) external returns (uint256);
+
+    function remove_liquidity(uint256 _amount, uint256[2] memory _min_amounts) external returns (uint256[2] memory);
+
+    function remove_liquidity_imbalance(
+        uint256[2] memory _amounts,
+        uint256 _max_burn_amount
+    ) external returns (uint256);
+
+    function calc_withdraw_one_coin(uint256 _token_amount, int128 i) external view returns (uint256);
+
+    function remove_liquidity_one_coin(uint256 _token_amount, int128 i, uint256 _min_amount) external returns (uint256);
+
+    function ramp_A(uint256 _future_A, uint256 _future_time) external;
+
+    function stop_ramp_A() external;
+
+    function commit_new_fee(uint256 _new_fee, uint256 _new_admin_fee) external;
+
+    function apply_new_fee() external;
+
+    function revert_new_parameters() external;
+
+    function commit_transfer_ownership(address _owner) external;
+
+    function apply_transfer_ownership() external;
+
+    function revert_transfer_ownership() external;
+
+    function admin_balances(uint256 i) external view returns (uint256);
+
+    function withdraw_admin_fees() external;
+
+    function donate_admin_fees() external;
+
+    function kill_me() external;
+
+    function unkill_me() external;
+
+    function coins(uint256 arg0) external view returns (address);
+
+    function balances(uint256 arg0) external view returns (uint256);
+
+    function fee() external view returns (uint256);
+
+    function admin_fee() external view returns (uint256);
+
+    function owner() external view returns (address);
+
+    function lp_token() external view returns (address);
+
+    function initial_A() external view returns (uint256);
+
+    function future_A() external view returns (uint256);
+
+    function initial_A_time() external view returns (uint256);
+
+    function future_A_time() external view returns (uint256);
+
+    function admin_actions_deadline() external view returns (uint256);
+
+    function transfer_ownership_deadline() external view returns (uint256);
+
+    function future_fee() external view returns (uint256);
+
+    function future_admin_fee() external view returns (uint256);
+
+    function future_owner() external view returns (address);
+}

--- a/src/contracts/interfaces/ITimelock.sol
+++ b/src/contracts/interfaces/ITimelock.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: ISC
+pragma solidity >=0.8.19;
+
+// NOTE: This file generated from https://etherscan.io/address/0x8412ebf45bAC1B340BbE8F318b928C466c4E39CA#code
+
+interface ITimelock {
+    event NewAdmin(address indexed newAdmin);
+    event NewPendingAdmin(address indexed newPendingAdmin);
+    event NewDelay(uint indexed newDelay);
+    event CancelTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint value,
+        string signature,
+        bytes data,
+        uint eta
+    );
+    event ExecuteTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint value,
+        string signature,
+        bytes data,
+        uint eta
+    );
+    event QueueTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint value,
+        string signature,
+        bytes data,
+        uint eta
+    );
+
+    function GRACE_PERIOD() external view returns (uint256);
+
+    function MAXIMUM_DELAY() external view returns (uint256);
+
+    function MINIMUM_DELAY() external view returns (uint256);
+
+    function acceptAdmin() external;
+
+    function admin() external view returns (address);
+
+    function cancelTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) external;
+
+    function delay() external view returns (uint256);
+
+    function executeTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) external returns (bytes memory);
+
+    function pendingAdmin() external view returns (address);
+
+    function queueTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) external returns (bytes32);
+
+    function queuedTransactions(bytes32) external view returns (bool);
+
+    function setDelay(uint256 delay_) external;
+
+    function setPendingAdmin(address pendingAdmin_) external;
+}

--- a/src/contracts/interfaces/ITimelock2Step.sol
+++ b/src/contracts/interfaces/ITimelock2Step.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+interface ITimelock2Step {
+    event TimelockTransferStarted(address indexed previousTimelock, address indexed newTimelock);
+    event TimelockTransferred(address indexed previousTimelock, address indexed newTimelock);
+
+    function acceptTransferTimelock() external;
+
+    function pendingTimelockAddress() external view returns (address);
+
+    function renounceTimelock() external;
+
+    function timelockAddress() external view returns (address);
+
+    function transferTimelock(address _newTimelock) external;
+}

--- a/src/contracts/interfaces/IVariableInterestRateV2.sol
+++ b/src/contracts/interfaces/IVariableInterestRateV2.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.19;
+
+interface IVariableInterestRateV2 {
+    function MAX_FULL_UTIL_RATE() external view returns (uint256);
+
+    function MAX_TARGET_UTIL() external view returns (uint256);
+
+    function MIN_FULL_UTIL_RATE() external view returns (uint256);
+
+    function MIN_TARGET_UTIL() external view returns (uint256);
+
+    function RATE_HALF_LIFE() external view returns (uint256);
+
+    function RATE_PREC() external view returns (uint256);
+
+    function UTIL_PREC() external view returns (uint256);
+
+    function VERTEX_RATE_PERCENT() external view returns (uint256);
+
+    function VERTEX_UTILIZATION() external view returns (uint256);
+
+    function ZERO_UTIL_RATE() external view returns (uint256);
+
+    function getNewRate(
+        uint256 _deltaTime,
+        uint256 _utilization,
+        uint64 _oldFullUtilizationInterest
+    ) external view returns (uint64 _newRatePerSec, uint64 _newFullUtilizationInterest);
+
+    function name() external pure returns (string memory);
+
+    function version() external pure returns (uint256 _major, uint256 _minor, uint256 _patch);
+}

--- a/src/contracts/interfaces/IVirtualPriceStableSwap.sol
+++ b/src/contracts/interfaces/IVirtualPriceStableSwap.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19;
+
+interface IVirtualPriceStableSwap {
+    function get_virtual_price() external view returns (uint256);
+}

--- a/src/contracts/interfaces/IWstEth.sol
+++ b/src/contracts/interfaces/IWstEth.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: ISC
+pragma solidity >=0.8.19;
+
+interface IWstEth {
+    function getStETHByWstETH(uint256) external view returns (uint256);
+}

--- a/src/contracts/interfaces/oracles/abstracts/IChainlinkOracleWithMaxDelay.sol
+++ b/src/contracts/interfaces/oracles/abstracts/IChainlinkOracleWithMaxDelay.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface IChainlinkOracleWithMaxDelay is IERC165 {
+    event SetMaximumOracleDelay(address oracle, uint256 oldMaxOracleDelay, uint256 newMaxOracleDelay);
+
+    function CHAINLINK_FEED_ADDRESS() external view returns (address);
+
+    function CHAINLINK_FEED_DECIMALS() external view returns (uint8);
+
+    function CHAINLINK_FEED_PRECISION() external view returns (uint256);
+
+    function getChainlinkPrice() external view returns (bool _isBadData, uint256 _updatedAt, uint256 _usdPerEth);
+
+    function maximumOracleDelay() external view returns (uint256);
+
+    function setMaximumOracleDelay(uint256 _newMaxOracleDelay) external;
+}

--- a/src/contracts/interfaces/oracles/abstracts/ICurvePoolEmaPriceOracleWithMinMax.sol
+++ b/src/contracts/interfaces/oracles/abstracts/ICurvePoolEmaPriceOracleWithMinMax.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface ICurvePoolEmaPriceOracleWithMinMax is IERC165 {
+    event SetMaximumCurvePoolEma(uint256 oldMaximum, uint256 newMaximum);
+    event SetMinimumCurvePoolEma(uint256 oldMinimum, uint256 newMinimum);
+
+    function CURVE_POOL_EMA_PRICE_ORACLE() external view returns (address);
+
+    function CURVE_POOL_EMA_PRICE_ORACLE_PRECISION() external view returns (uint256);
+
+    function getCurvePoolToken1EmaPrice() external view returns (uint256 _emaPrice);
+
+    function maximumCurvePoolEma() external view returns (uint256);
+
+    function minimumCurvePoolEma() external view returns (uint256);
+
+    function setMaximumCurvePoolEma(uint256 _maximumPrice) external;
+
+    function setMinimumCurvePoolEma(uint256 _minimumPrice) external;
+}

--- a/src/contracts/interfaces/oracles/abstracts/ICurvePoolVirtualPriceOracleWithMinMax.sol
+++ b/src/contracts/interfaces/oracles/abstracts/ICurvePoolVirtualPriceOracleWithMinMax.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface ICurvePoolVirtualPriceOracleWithMinMax is IERC165 {
+    event SetMaximumCurvePoolVirtualPrice(uint256 oldMaximum, uint256 newMaximum);
+    event SetMinimumCurvePoolVirtualPrice(uint256 oldMinimum, uint256 newMinimum);
+
+    function CURVE_POOL_VIRTUAL_PRICE() external view returns (address);
+
+    function CURVE_POOL_VIRTUAL_PRICE_PRECISION() external view returns (uint256);
+
+    function getCurvePoolVirtualPrice() external view returns (uint256 _virtualPrice);
+
+    function maximumCurvePoolVirtualPrice() external view returns (uint256);
+
+    function minimumCurvePoolVirtualPrice() external view returns (uint256);
+
+    function setMaximumCurvePoolVirtualPrice(uint256 _newMaximum) external;
+
+    function setMinimumCurvePoolVirtualPrice(uint256 _newMinimum) external;
+}

--- a/src/contracts/interfaces/oracles/abstracts/IEthUsdChainlinkOracleWithMaxDelay.sol
+++ b/src/contracts/interfaces/oracles/abstracts/IEthUsdChainlinkOracleWithMaxDelay.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface IEthUsdChainlinkOracleWithMaxDelay is IERC165 {
+    event SetMaximumEthUsdOracleDelay(uint256 oldMaxOracleDelay, uint256 newMaxOracleDelay);
+
+    function ETH_USD_CHAINLINK_FEED_ADDRESS() external view returns (address);
+
+    function ETH_USD_CHAINLINK_FEED_DECIMALS() external view returns (uint8);
+
+    function ETH_USD_CHAINLINK_FEED_PRECISION() external view returns (uint256);
+
+    function maximumEthUsdOracleDelay() external view returns (uint256);
+
+    function getEthUsdChainlinkPrice() external view returns (bool _isBadData, uint256 _updatedAt, uint256 _usdPerEth);
+
+    function setMaximumEthUsdOracleDelay(uint256 _newMaxOracleDelay) external;
+}

--- a/src/contracts/interfaces/oracles/abstracts/IUniswapV3SingleTwapOracle.sol
+++ b/src/contracts/interfaces/oracles/abstracts/IUniswapV3SingleTwapOracle.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface IUniswapV3SingleTwapOracle is IERC165 {
+    event SetTwapDuration(uint256 oldTwapDuration, uint256 newTwapDuration);
+
+    function TWAP_PRECISION() external view returns (uint128);
+
+    function UNISWAP_V3_TWAP_BASE_TOKEN() external view returns (address);
+
+    function UNISWAP_V3_TWAP_QUOTE_TOKEN() external view returns (address);
+
+    function UNI_V3_PAIR_ADDRESS() external view returns (address);
+
+    function getUniswapV3Twap() external view returns (uint256 _twap);
+
+    function twapDuration() external view returns (uint32);
+
+    function setTwapDuration(uint32 _newTwapDuration) external;
+}

--- a/src/contracts/libraries/SafeERC20.sol
+++ b/src/contracts/libraries/SafeERC20.sol
@@ -64,4 +64,8 @@ library SafeERC20 {
     function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {
         OZSafeERC20.safeTransferFrom(token, from, to, value);
     }
+
+    function safeApprove(IERC20 token, address to, uint256 value) internal {
+        OZSafeERC20.safeApprove(token, to, value);
+    }
 }


### PR DESCRIPTION
Bumps the contract in `src/` to `59c0d14ebb656ee73d0002e59c02ffc731818749` on the current development repo. 